### PR TITLE
[]add renovate-approve to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 * @contentful/team-security
-package.json
-package-lock.json
+package.json @app/renovate-approve
+package-lock.json @app/renovate-approve
 .github/workflows


### PR DESCRIPTION
Per [this](https://github.com/renovatebot/config-help/issues/114#issuecomment-665916720) comment renovate-approve can be set in the codeowners and keep the ruleset compliant, without having to explicitly bypass the requirement.